### PR TITLE
Glaive support: Switched from HidSharp to HidLibrary

### DIFF
--- a/CUE.NET.csproj
+++ b/CUE.NET.csproj
@@ -36,8 +36,8 @@
     <DocumentationFile>bin\CUE.NET.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HidSharp, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\HidSharp.1.5\lib\net35\HidSharp.dll</HintPath>
+    <Reference Include="HidLibrary, Version=3.2.46.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\hidlibrary.3.2.46.0\lib\HidLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="hidlibrary" version="3.2.46.0" targetFramework="net45" />
   <package id="HidSharp" version="1.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
HidSharp had problems with connecting to the device. Switching to HidLibrary appears to fix these problems as connection is successful every time and the device gets initialized properly.