### PR TITLE
Add sanity-check to CueSDK.EnableKeypressHandler()

### DIFF
--- a/CueSDK.cs
+++ b/CueSDK.cs
@@ -269,6 +269,9 @@ namespace CUE.NET
             if (!IsInitialized)
                 throw new WrapperException("CueSDK isn't initialized.");
 
+            if (_onKeyPressedDelegate != null)
+                return;
+
             _onKeyPressedDelegate = OnKeyPressed;
             _CUESDK.CorsairRegisterKeypressCallback(Marshal.GetFunctionPointerForDelegate(_onKeyPressedDelegate), IntPtr.Zero);
         }


### PR DESCRIPTION
This modifies `EnableKeypressHandler()` to check the value of `_onKeyPressedDelegate` value in order to determine whether  `EnableKeypressHandler()` has already been called before. This resolves issue #69.